### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Status: Meme
 
-A 2kB zero-config router and prefetcher that makes a stati site feel like a blazingly fast SPA.
+A 2kB zero-config router and prefetcher that makes a static site feel like a blazingly fast SPA.
 
 ## Why?
 


### PR DESCRIPTION
There was a mistake in the spelling of static. 
This commit fixes that typo