### PR TITLE
Add X-Flamethrower header to fetch requests

### DIFF
--- a/lib/router.ts
+++ b/lib/router.ts
@@ -150,7 +150,7 @@ export class Router {
         addToPushState(next);
 
         // Fetch next document
-        const res = await fetch(next);
+        const res = await fetch(next, { headers: { 'X-Flamethrower': '1' } });
         const html = await res.text();
         const nextDoc = formatNextDocument(html);
 


### PR DESCRIPTION
This PR adds a `X-Flamethrower: 1` header to each request Flamethrower makes. This should make Flamethrower easier to identify.