### PR TITLE
Rename global events to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ router.back();
 router.forward();
 
 // Listen to events
-window.addEventListener('router:fetch', showLoader);
-window.addEventListener('router:end', hideLoader);
+window.addEventListener('flamethrower:router:fetch', showLoader);
+window.addEventListener('flamethrower:router:end', hideLoader);
 
 // Disable it
 router.enabled = false;
@@ -72,7 +72,7 @@ Prefecthing is disabled by default.
 
 ```js
 const router = flamethrower({ prefetch: 'visible' });
-``` 
+```
 
 ### Misc
 

--- a/lib/router.ts
+++ b/lib/router.ts
@@ -180,7 +180,7 @@ export class Router {
       if (['popstate', 'link', 'go'].includes(type) && next !== prev) {
         this.opts.log && console.time('⏱️');
 
-        window.dispatchEvent(new CustomEvent('router:fetch'));
+        window.dispatchEvent(new CustomEvent('flamethrower:router:fetch'));
 
         // Update window history
         addToPushState(next);
@@ -212,7 +212,7 @@ export class Router {
         // handle scroll
         scrollToTop(type);
 
-        window.dispatchEvent(new CustomEvent('router:end'));
+        window.dispatchEvent(new CustomEvent('flamethrower:router:end'));
 
         // delay for any js rendered links
         setTimeout(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flamethrower-router",
-  "version": "0.0.0-meme.6",
+  "version": "0.0.0-meme.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flamethrower-router",
-      "version": "0.0.0-meme.6",
+      "version": "0.0.0-meme.7",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flamethrower-router",
-  "version": "0.0.0-meme.4",
+  "version": "0.0.0-meme.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flamethrower-router",
-      "version": "0.0.0-meme.4",
+      "version": "0.0.0-meme.6",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flamethrower-router",
-  "version": "0.0.0-meme.6",
+  "version": "0.0.0-meme.7",
   "description": "Blazingly fast SPA-like router for static sites",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
I think global events should have a more specific name so you know where they are coming from.