### PR TITLE
Improved data-cold searching

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -30,11 +30,11 @@
     <div id="load-bar"></div>
     <h1 id="heading">Home</h1>
     <a href="/">Home</a> | <a id="about" href="/about">About</a> |
-
+    <a href="/" data-cold>Home (cold)</a>
     <div id="keep" flamethrower-preserve>
       <article>
         <p>This text should be preserved when starting from home</p>
-      </article> 
+      </article>
     </div>
 
     <script>

--- a/lib/handlers.ts
+++ b/lib/handlers.ts
@@ -74,7 +74,7 @@ export function handleLinkClick(e: MouseEvent): RouteChangeData {
   }
 
   // User opt-out
-  if (anchor && 'cold' in anchor?.dataset) {
+  if (anchor && anchor?.closest('[data-cold]')) {
     return { type: 'disqualified' };
   }
 


### PR DESCRIPTION
This PR adds the ability to set data-cold in parent nodes of a link. For example:

```html

<div data-cold>
  <!-- cold area, all links here will be cold (i.e. full page reload) -->
  <a href="/cold.html">Link</a>
</div>

```