### PR TITLE
add vercel example url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ You can deploy Flamethrower to [Vercel](http://vercel.com/) as follows:
 npm run deploy
 ```
 
-This uses the [Build Output API](https://vercel.com/docs/build-output-api/v3) and the [Vercel CLI](https://vercel.com/cli) to deploy the `/example` folder.
+This uses the [Build Output API](https://vercel.com/docs/build-output-api/v3) and the [Vercel CLI](https://vercel.com/cli) to deploy the `/example` folder. Check it out [here](https://flamethrower.vercel.app/).


### PR DESCRIPTION
This PR addds the [URL](https://flamethrower.vercel.app/) for the Vercel deploy of `example` (setup in #51)  to the README to help make it easier to find! 

Thanks to @codediodeio and @leerob.