### PR TITLE
Fix typo 'prefecthing' to 'prefetching'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ window.addEventListener('flamethrower:router:fetch-progress', ({ detail }) => {
 
 ### Prefetching
 
-Prefecthing is disabled by default.
+Prefetching is disabled by default.
 
 - `visible`: prefetch visible links on the page with IntersectionObserver
 - `hover`: prefetch links on hover


### PR DESCRIPTION
Fixed a small typo in the README document.
I followed the "GitHub Pull Request in 100 Seconds" video for reference.
Thanks for leaving these typos for us to change!